### PR TITLE
chore: use `integ:snapshot-all` in `postUpgradeTask`

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -268,7 +268,7 @@
           "spawn": "test:update"
         },
         {
-          "spawn": "integ:process-metrics:snapshot"
+          "spawn": "integ:snapshot-all"
         }
       ]
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -50,7 +50,7 @@ project.upgradeWorkflow?.postUpgradeTask.spawn(
   project.tasks.tryFind("test:update")
 );
 project.upgradeWorkflow?.postUpgradeTask.spawn(
-  project.tasks.tryFind("integ:process-metrics:snapshot")
+  project.tasks.tryFind("integ:snapshot-all")
 );
 
 project.synth();


### PR DESCRIPTION
use `integ:snapshot-all` in `postUpgradeTask`